### PR TITLE
Fix Sunricher ZG2858A color data extraction and temperature unit

### DIFF
--- a/blueprints/controllers/sunricher/sunricher_zg2858a/sunricher_zg2858a.yaml
+++ b/blueprints/controllers/sunricher/sunricher_zg2858a/sunricher_zg2858a.yaml
@@ -402,8 +402,12 @@ condition:
   - "{{ trigger.payload_json.action is defined and trigger.payload_json.action not in ['', None] }}"
 action:
   - variables:
-      # Extract the action from the MQTT payload
+      # Extract the action and color data from the MQTT payload at trigger time,
+      # so they remain accessible in nested choose/sequence/data templates.
       trigger_action: "{{ trigger.payload_json.action }}"
+      action_color_temperature: "{{ trigger.payload_json.action_color_temperature | int(0) }}"
+      action_color_x: "{{ trigger.payload_json.action_color.x | float(0) if trigger.payload_json.action_color is not none and trigger.payload_json.action_color is mapping else 0 }}"
+      action_color_y: "{{ trigger.payload_json.action_color.y | float(0) if trigger.payload_json.action_color is not none and trigger.payload_json.action_color is mapping else 0 }}"
       # Define target entity from zone in the trigger action
       entity: >
         {% if "1" in trigger_action %}
@@ -442,8 +446,8 @@ action:
           - service: light.turn_on
             data:
               xy_color:
-                - '{{ trigger.payload_json.action_color.x | float }}'
-                - '{{ trigger.payload_json.action_color.y | float }}'
+                - '{{ action_color_x }}'
+                - '{{ action_color_y }}'
               transition: '{{ transition_single }}'
             target:
               device_id: '{{ entity }}'
@@ -451,7 +455,7 @@ action:
         sequence:
           - service: light.turn_on
             data:
-              color_temp: '{{ trigger.payload_json.action_color_temperature | int }}'
+              color_temp: '{{ action_color_temperature }}'
               transition: '{{ transition_single }}'
             target:
               device_id: '{{ entity }}'

--- a/blueprints/controllers/sunricher/sunricher_zg2858a/sunricher_zg2858a.yaml
+++ b/blueprints/controllers/sunricher/sunricher_zg2858a/sunricher_zg2858a.yaml
@@ -455,7 +455,7 @@ action:
         sequence:
           - service: light.turn_on
             data:
-              color_temp: '{{ action_color_temperature }}'
+              color_temp_kelvin: "{{ (1000000 / action_color_temperature) | int }}"
               transition: '{{ transition_single }}'
             target:
               device_id: '{{ entity }}'

--- a/blueprints/controllers/sunricher/sunricher_zg2858a/sunricher_zg2858a.yaml
+++ b/blueprints/controllers/sunricher/sunricher_zg2858a/sunricher_zg2858a.yaml
@@ -405,9 +405,9 @@ action:
       # Extract the action and color data from the MQTT payload at trigger time,
       # so they remain accessible in nested choose/sequence/data templates.
       trigger_action: "{{ trigger.payload_json.action }}"
-      action_color_temperature: "{{ trigger.payload_json.action_color_temperature | default(0) | int }}"
-      action_color_x: "{{ trigger.payload_json.get('action_color', {}).get('x', 0) | float }}"
-      action_color_y: "{{ trigger.payload_json.get('action_color', {}).get('y', 0) | float }}"
+      action_color_temperature: "{{ trigger.payload_json['action_color_temperature'] | int if 'action_color_temperature' in trigger.payload_json else 0 }}"
+      action_color_x: "{{ trigger.payload_json['action_color']['x'] | float if 'action_color' in trigger.payload_json else 0 }}"
+      action_color_y: "{{ trigger.payload_json['action_color']['y'] | float if 'action_color' in trigger.payload_json else 0 }}"
       # Define target entity from zone in the trigger action
       entity: >
         {% if "1" in trigger_action %}

--- a/blueprints/controllers/sunricher/sunricher_zg2858a/sunricher_zg2858a.yaml
+++ b/blueprints/controllers/sunricher/sunricher_zg2858a/sunricher_zg2858a.yaml
@@ -405,9 +405,9 @@ action:
       # Extract the action and color data from the MQTT payload at trigger time,
       # so they remain accessible in nested choose/sequence/data templates.
       trigger_action: "{{ trigger.payload_json.action }}"
-      action_color_temperature: "{{ trigger.payload_json.action_color_temperature | int(0) }}"
-      action_color_x: "{{ trigger.payload_json.action_color.x | float(0) if trigger.payload_json.action_color is not none and trigger.payload_json.action_color is mapping else 0 }}"
-      action_color_y: "{{ trigger.payload_json.action_color.y | float(0) if trigger.payload_json.action_color is not none and trigger.payload_json.action_color is mapping else 0 }}"
+      action_color_temperature: "{{ trigger.payload_json.action_color_temperature | default(0) | int }}"
+      action_color_x: "{{ trigger.payload_json.action_color.x | default(0) | float }}"
+      action_color_y: "{{ trigger.payload_json.action_color.y | default(0) | float }}"
       # Define target entity from zone in the trigger action
       entity: >
         {% if "1" in trigger_action %}

--- a/blueprints/controllers/sunricher/sunricher_zg2858a/sunricher_zg2858a.yaml
+++ b/blueprints/controllers/sunricher/sunricher_zg2858a/sunricher_zg2858a.yaml
@@ -406,8 +406,8 @@ action:
       # so they remain accessible in nested choose/sequence/data templates.
       trigger_action: "{{ trigger.payload_json.action }}"
       action_color_temperature: "{{ trigger.payload_json.action_color_temperature | default(0) | int }}"
-      action_color_x: "{{ trigger.payload_json.action_color.x | default(0) | float }}"
-      action_color_y: "{{ trigger.payload_json.action_color.y | default(0) | float }}"
+      action_color_x: "{{ trigger.payload_json.get('action_color', {}).get('x', 0) | float }}"
+      action_color_y: "{{ trigger.payload_json.get('action_color', {}).get('y', 0) | float }}"
       # Define target entity from zone in the trigger action
       entity: >
         {% if "1" in trigger_action %}


### PR DESCRIPTION
## Summary
This PR improves the reliability of color data handling in the Sunricher ZG2858A automation by extracting MQTT payload values at trigger time and fixes the color temperature unit conversion.

## Key Changes
- **Extract color data at trigger time**: Added variables for `action_color_temperature`, `action_color_x`, and `action_color_y` at the beginning of the action sequence. This ensures these values are captured from the MQTT payload immediately and remain accessible in nested choose/sequence/data templates, preventing potential issues with late template evaluation.
- **Add safe fallback values**: Each extracted color variable includes a fallback value (0) if the corresponding key is missing from the MQTT payload, preventing template errors.
- **Fix color temperature unit**: Changed from `color_temp` (deprecated mireds unit) to `color_temp_kelvin` with proper conversion formula `(1000000 / action_color_temperature)` to convert from mireds to Kelvin, ensuring compatibility with current Home Assistant light service API.
- **Simplify template references**: Updated service call data to reference the pre-extracted variables instead of directly accessing the trigger payload, improving readability and maintainability.

## Implementation Details
The color data extraction follows Home Assistant best practices by capturing trigger data early in the automation sequence, making it available throughout nested conditionals and sequences without re-evaluating the trigger context.

https://claude.ai/code/session_013RXwJddCoPibVKweXeiSu3